### PR TITLE
Remove redeclared variable `QUIT` in Python code

### DIFF
--- a/python/ch02_listing_source.py
+++ b/python/ch02_listing_source.py
@@ -6,8 +6,6 @@ import unittest
 import urlparse
 import uuid
 
-QUIT = False
-
 # <start id="_1311_14471_8266"/>
 def check_token(conn, token):
     return conn.hget('login:', token)   #A


### PR DESCRIPTION
The above `QUIT` is not used.